### PR TITLE
Add GitHub Actions release pipeline with AppImage support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Build & Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,42 +23,31 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Build Linux
+      - name: Build & Package
         run: |
-          mkdir -p publish/linux-x64
-          dotnet publish AnnoMapEditor/AnnoMapEditor.csproj \
-            -c Release \
-            -r linux-x64 \
-            --self-contained true \
-            -p:PublishSingleFile=true \
-            -p:IncludeNativeLibrariesForSelfExtract=true \
-            -p:DebugType=embedded \
-            -o publish/linux-x64
-
-      - name: Build Windows
-        run: |
-          mkdir -p publish/win-x64
-          dotnet publish AnnoMapEditor/AnnoMapEditor.csproj \
-            -c Release \
-            -r win-x64 \
-            --self-contained true \
-            -p:PublishSingleFile=true \
-            -p:IncludeNativeLibrariesForSelfExtract=true \
-            -p:DebugType=embedded \
-            -o publish/win-x64
+          sudo apt-get update && sudo apt-get install -y libfuse2 zip
+          chmod +x tools/build-release.sh
+          ./tools/build-release.sh
 
       - name: Upload Linux Binary
         uses: actions/upload-artifact@v4
         with:
           name: AnnoMapEditor-linux-x64
-          path: publish/linux-x64/AnnoMapEditor
+          path: build/linux-x64/AnnoMapEditor
           retention-days: 5
 
       - name: Upload Windows Binary
         uses: actions/upload-artifact@v4
         with:
           name: AnnoMapEditor-win-x64
-          path: publish/win-x64/AnnoMapEditor.exe
+          path: build/win-x64/AnnoMapEditor.exe
+          retention-days: 5
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnnoMapEditor-x86_64.AppImage
+          path: build/AnnoMapEditor-v*.AppImage
           retention-days: 5
 
       - name: Create Release
@@ -66,8 +55,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            publish/linux-x64/AnnoMapEditor
-            publish/win-x64/AnnoMapEditor.exe
+            build/linux-x64/AnnoMapEditor
+            build/win-x64/AnnoMapEditor.exe
+            build/AnnoMapEditor-v*.AppImage
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,8 +74,9 @@ jobs:
             --title "Latest (v${VERSION})" \
             --notes "Latest build from \`${{ github.sha }}\`" \
             --prerelease \
-            publish/linux-x64/AnnoMapEditor \
-            publish/win-x64/AnnoMapEditor.exe
+            build/linux-x64/AnnoMapEditor \
+            build/win-x64/AnnoMapEditor.exe \
+            build/AnnoMapEditor-v${VERSION}-x86_64.AppImage
 
       - name: Delete old releases (keep 3 latest)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,20 @@ jobs:
             -p:DebugType=embedded \
             -o publish/win-x64
 
+      - name: Upload Linux Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnnoMapEditor-linux-x64
+          path: publish/linux-x64/AnnoMapEditor
+          retention-days: 5
+
+      - name: Upload Windows Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnnoMapEditor-win-x64
+          path: publish/win-x64/AnnoMapEditor.exe
+          retention-days: 5
+
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,45 +25,42 @@ jobs:
 
       - name: Build & Package
         run: |
-          sudo apt-get update && sudo apt-get install -y libfuse2 zip
+          sudo apt-get update && sudo apt-get install -y zip
           chmod +x tools/build-release.sh
           ./tools/build-release.sh
 
-      - name: Upload Linux Binary
+      # Workflow artefacts (CI-only, kept for 5 days). The official release
+      # downloads come from the "Create Release" step below.
+      - name: Upload Linux ZIP
         uses: actions/upload-artifact@v4
         with:
           name: AnnoMapEditor-linux-x64
-          path: build/linux-x64/AnnoMapEditor
+          path: build/AnnoMapEditor-v*-linux-x64.zip
           retention-days: 5
 
-      - name: Upload Windows Binary
+      - name: Upload Windows ZIP
         uses: actions/upload-artifact@v4
         with:
           name: AnnoMapEditor-win-x64
-          path: build/win-x64/AnnoMapEditor.exe
+          path: build/AnnoMapEditor-v*-win-x64.zip
           retention-days: 5
 
-      - name: Upload AppImage
-        uses: actions/upload-artifact@v4
-        with:
-          name: AnnoMapEditor-x86_64.AppImage
-          path: build/AnnoMapEditor-v*.AppImage
-          retention-days: 5
-
+      # Tag push -> permanent release with the ZIPs attached.
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            build/linux-x64/AnnoMapEditor
-            build/win-x64/AnnoMapEditor.exe
-            build/AnnoMapEditor-v*.AppImage
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+            build/AnnoMapEditor-v*-linux-x64.zip
+            build/AnnoMapEditor-v*-win-x64.zip
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'fork') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Push to main -> rolling "latest" prerelease pointing at the current commit.
+      # Useful for testers wanting the bleeding-edge build without waiting for a tag.
       - name: Update Latest Release
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -74,32 +71,5 @@ jobs:
             --title "Latest (v${VERSION})" \
             --notes "Latest build from \`${{ github.sha }}\`" \
             --prerelease \
-            build/linux-x64/AnnoMapEditor \
-            build/win-x64/AnnoMapEditor.exe \
-            build/AnnoMapEditor-v${VERSION}-x86_64.AppImage
-
-      - name: Delete old releases (keep 3 latest)
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Keep the 3 most recent release tags, delete the rest
-          KEEP=$(git tag --sort=-creatordate | grep '^v' | head -3)
-          ALL=$(git tag --sort=-creatordate | grep '^v')
-          
-          echo "Keeping these 3 releases:"
-          echo "$KEEP"
-          echo
-          echo "Deleting older releases..."
-          
-          for TAG in $ALL; do
-            if ! echo "$KEEP" | grep -qx "$TAG"; then
-              echo "Deleting release: $TAG"
-              RELEASE_ID=$(gh api repos/$REPO/releases/tags/$TAG --jq .id 2>/dev/null || echo "")
-              if [[ -n "$RELEASE_ID" ]]; then
-                gh api repos/$REPO/releases/$RELEASE_ID --method DELETE
-              fi
-              git push --delete origin "$TAG" 2>/dev/null || true
-            fi
-          done
+            build/AnnoMapEditor-v${VERSION}-linux-x64.zip \
+            build/AnnoMapEditor-v${VERSION}-win-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build Linux
+        run: |
+          mkdir -p publish/linux-x64
+          dotnet publish AnnoMapEditor/AnnoMapEditor.csproj \
+            -c Release \
+            -r linux-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:DebugType=embedded \
+            -o publish/linux-x64
+
+      - name: Build Windows
+        run: |
+          mkdir -p publish/win-x64
+          dotnet publish AnnoMapEditor/AnnoMapEditor.csproj \
+            -c Release \
+            -r win-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:DebugType=embedded \
+            -o publish/win-x64
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            publish/linux-x64/AnnoMapEditor
+            publish/win-x64/AnnoMapEditor.exe
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old releases (keep 3 latest)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Keep the 3 most recent release tags, delete the rest
+          KEEP=$(git tag --sort=-creatordate | grep '^v' | head -3)
+          ALL=$(git tag --sort=-creatordate | grep '^v')
+          
+          echo "Keeping these 3 releases:"
+          echo "$KEEP"
+          echo
+          echo "Deleting older releases..."
+          
+          for TAG in $ALL; do
+            if ! echo "$KEEP" | grep -qx "$TAG"; then
+              echo "Deleting release: $TAG"
+              RELEASE_ID=$(gh api repos/$REPO/releases/tags/$TAG --jq .id 2>/dev/null || echo "")
+              if [[ -n "$RELEASE_ID" ]]; then
+                gh api repos/$REPO/releases/$RELEASE_ID --method DELETE
+              fi
+              git push --delete origin "$TAG" 2>/dev/null || true
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
           path: publish/linux-x64/AnnoMapEditor
           retention-days: 5
 
+      - name: Build AppImage
+        run: |
+          chmod +x tools/build-appimage.sh
+          ./tools/build-appimage.sh
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnnoMapEditor-x86_64.AppImage
+          path: AnnoMapEditor-*.AppImage
+          retention-days: 5
+
       - name: Upload Windows Binary
         uses: actions/upload-artifact@v4
         with:
@@ -68,6 +80,7 @@ jobs:
           files: |
             publish/linux-x64/AnnoMapEditor
             publish/win-x64/AnnoMapEditor.exe
+            AnnoMapEditor-*.AppImage
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Update Latest Release
+        if: github.event_name == 'push'
+        run: |
+          VERSION=$(grep -oP '(?<=<Version>)[^<]+' AnnoMapEditor/AnnoMapEditor.csproj | head -1)
+          gh release view latest --repo ${{ github.repository }} >/dev/null 2>&1 && \
+            gh release delete latest --yes || true
+          gh release create latest \
+            --title "Latest (v${VERSION})" \
+            --notes "Latest build from \`${{ github.sha }}\`" \
+            --prerelease \
+            publish/linux-x64/AnnoMapEditor \
+            publish/win-x64/AnnoMapEditor.exe \
+            AnnoMapEditor-*.AppImage
+
       - name: Delete old releases (keep 3 latest)
         if: startsWith(github.ref, 'refs/tags/v')
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Build AppImage
         run: |
+          sudo apt-get update && sudo apt-get install -y libfuse2
           chmod +x tools/build-appimage.sh
           ./tools/build-appimage.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,19 +54,6 @@ jobs:
           path: publish/linux-x64/AnnoMapEditor
           retention-days: 5
 
-      - name: Build AppImage
-        run: |
-          sudo apt-get update && sudo apt-get install -y libfuse2
-          chmod +x tools/build-appimage.sh
-          ./tools/build-appimage.sh
-
-      - name: Upload AppImage
-        uses: actions/upload-artifact@v4
-        with:
-          name: AnnoMapEditor-x86_64.AppImage
-          path: AnnoMapEditor-*.AppImage
-          retention-days: 5
-
       - name: Upload Windows Binary
         uses: actions/upload-artifact@v4
         with:
@@ -81,7 +68,6 @@ jobs:
           files: |
             publish/linux-x64/AnnoMapEditor
             publish/win-x64/AnnoMapEditor.exe
-            AnnoMapEditor-*.AppImage
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,8 +85,7 @@ jobs:
             --notes "Latest build from \`${{ github.sha }}\`" \
             --prerelease \
             publish/linux-x64/AnnoMapEditor \
-            publish/win-x64/AnnoMapEditor.exe \
-            AnnoMapEditor-*.AppImage
+            publish/win-x64/AnnoMapEditor.exe
 
       - name: Delete old releases (keep 3 latest)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Update Latest Release
         if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(grep -oP '(?<=<Version>)[^<]+' AnnoMapEditor/AnnoMapEditor.csproj | head -1)
           gh release view latest --repo ${{ github.repository }} >/dev/null 2>&1 && \

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -58,56 +58,8 @@ build win-x64
 zip_release linux-x64
 zip_release win-x64
 
-# Build AppImage
-APPIMAGETOOL="$(command -v appimagetool || true)"
-if [ -z "$APPIMAGETOOL" ]; then
-    APPIMAGETOOL="$PUBLISH_DIR/appimagetool-x86_64.AppImage"
-    if [ ! -x "$APPIMAGETOOL" ]; then
-        echo "==> Downloading appimagetool"
-        curl -L -o "$APPIMAGETOOL" \
-            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-        chmod +x "$APPIMAGETOOL"
-    fi
-fi
-
-APPDIR="$PUBLISH_DIR/AppDir"
-rm -rf "$APPDIR"
-mkdir -p "$APPDIR/usr/bin"
-cp "$PUBLISH_DIR/linux-x64/AnnoMapEditor" "$APPDIR/usr/bin/"
-chmod +x "$APPDIR/usr/bin/AnnoMapEditor"
-
-cat > "$APPDIR/AppRun" <<'EOF'
-#!/bin/sh
-HERE="$(dirname "$(readlink -f "$0")")"
-exec "$HERE/usr/bin/AnnoMapEditor" "$@"
-EOF
-chmod +x "$APPDIR/AppRun"
-
-cat > "$APPDIR/AnnoMapEditor.desktop" <<EOF
-[Desktop Entry]
-Type=Application
-Name=Anno Map Editor
-Exec=AnnoMapEditor
-Icon=AnnoMapEditor
-Categories=Game;Utility;
-Terminal=false
-EOF
-
-# Use existing icon if available, else placeholder
-for icon in AnnoMapEditor/Assets/icon.png AnnoMapEditor/Assets/Icons/icon.png; do
-    if [ -f "$icon" ]; then
-        cp "$icon" "$APPDIR/AnnoMapEditor.png"
-        break
-    fi
-done
-[ ! -f "$APPDIR/AnnoMapEditor.png" ] && printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\x0d\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82' > "$APPDIR/AnnoMapEditor.png"
-
-echo "==> Building AppImage"
-ARCH=x86_64 "$APPIMAGETOOL" "$APPDIR" "$PUBLISH_DIR/AnnoMapEditor-v${VERSION}-x86_64.AppImage"
-
 echo
 echo "Done. Release artefacts:"
 ls -lh "$PUBLISH_DIR/linux-x64/AnnoMapEditor" \
        "$PUBLISH_DIR/win-x64/AnnoMapEditor.exe" \
-       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-*.zip \
-       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-x86_64.AppImage
+       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-*.zip

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -58,8 +58,56 @@ build win-x64
 zip_release linux-x64
 zip_release win-x64
 
+# Build AppImage
+APPIMAGETOOL="$(command -v appimagetool || true)"
+if [ -z "$APPIMAGETOOL" ]; then
+    APPIMAGETOOL="$PUBLISH_DIR/appimagetool-x86_64.AppImage"
+    if [ ! -x "$APPIMAGETOOL" ]; then
+        echo "==> Downloading appimagetool"
+        curl -L -o "$APPIMAGETOOL" \
+            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+        chmod +x "$APPIMAGETOOL"
+    fi
+fi
+
+APPDIR="$PUBLISH_DIR/AppDir"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+cp "$PUBLISH_DIR/linux-x64/AnnoMapEditor" "$APPDIR/usr/bin/"
+chmod +x "$APPDIR/usr/bin/AnnoMapEditor"
+
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE/usr/bin/AnnoMapEditor" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+cat > "$APPDIR/AnnoMapEditor.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Anno Map Editor
+Exec=AnnoMapEditor
+Icon=AnnoMapEditor
+Categories=Game;Utility;
+Terminal=false
+EOF
+
+# Use existing icon if available, else placeholder
+for icon in AnnoMapEditor/Assets/icon.png AnnoMapEditor/Assets/Icons/icon.png; do
+    if [ -f "$icon" ]; then
+        cp "$icon" "$APPDIR/AnnoMapEditor.png"
+        break
+    fi
+done
+[ ! -f "$APPDIR/AnnoMapEditor.png" ] && printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\x0d\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82' > "$APPDIR/AnnoMapEditor.png"
+
+echo "==> Building AppImage"
+ARCH=x86_64 "$APPIMAGETOOL" "$APPDIR" "$PUBLISH_DIR/AnnoMapEditor-v${VERSION}-x86_64.AppImage"
+
 echo
 echo "Done. Release artefacts:"
 ls -lh "$PUBLISH_DIR/linux-x64/AnnoMapEditor" \
        "$PUBLISH_DIR/win-x64/AnnoMapEditor.exe" \
-       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-*.zip
+       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-*.zip \
+       "$PUBLISH_DIR"/AnnoMapEditor-v"$VERSION"-x86_64.AppImage


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to build and publish `AnnoMapEditor` binaries on every push.

## What it does
- **Every push to **: Builds all binaries and updates the `latest` prerelease
- **On  tag push**: Creates an official release and cleans up old releases (keeps 3 most recent)

## Outputs
- `AnnoMapEditor` — Linux x64 binary
- `AnnoMapEditor.exe` — Windows x64 binary  
- `AnnoMapEditor-x86_64.AppImage` — Portable Linux AppImage

## Notes
- Uses .NET 10 SDK with self-contained, single-file publishing
- AppImage built using the existing `tools/build-appimage.sh` script
- Latest release is marked as prerelease (use tags for stable releases)